### PR TITLE
Allow configuration of output path

### DIFF
--- a/wiki2schedule_camp15.py
+++ b/wiki2schedule_camp15.py
@@ -7,6 +7,7 @@ import dateutil.parser
 from datetime import datetime
 import pytz
 import os
+import sys
 
 days = []
 de_tz = pytz.timezone('Europe/Amsterdam')
@@ -15,6 +16,10 @@ de_tz = pytz.timezone('Europe/Amsterdam')
 import voc.tools
 
 output_dir = "/srv/www/schedule/camp15"
+
+if len(sys.argv) == 2:
+    output_dir = sys.argv[1]
+
 if not os.path.exists(output_dir):
     os.mkdir(output_dir) 
 os.chdir(output_dir)

--- a/wiki2schedule_camp15.py
+++ b/wiki2schedule_camp15.py
@@ -109,6 +109,7 @@ def main():
         room = ''
         workshop_room_session = False
         # TODO can one Event take place in multiple rooms? 
+        # WORKAROND If that is the case just pick the first one
         if len(event['Has session location']) == 1:
             #print event['Has session location']
             room = event['Has session location'][0]['fulltext'].split(':', 1)[1]
@@ -117,7 +118,8 @@ def main():
         elif len(event['Has session location']) == 0:
             print "  has no room yet"
         else:
-            raise "  has multiple rooms ???"
+            print "WARNING: has multiple rooms ???, just picking the first one…"
+            event['Has session location'] = event['Has session location'][0]
         
         session = sessions[session_wiki_name]['printouts'];
         session['Has title'] = [session_wiki_name.split(':', 2)[1]]


### PR DESCRIPTION
Two tiny changes:

- Allow the output path to be overridden by a command line argument
- Don't bail on multi-room events. Pick the first room for now.