### PR TITLE
Parse event titles with colon (':') correctly

### DIFF
--- a/wiki2schedule_33C3.py
+++ b/wiki2schedule_33C3.py
@@ -273,8 +273,7 @@ def process_wiki_events(events, sessions):
             # print json.dumps(wiki_session, indent=4)
             session = wiki_session['printouts'];
             try:
-                # TODO: use remove_prefix()?
-                session['Has title'] = [session_wiki_name.split(':', 2)[1]]
+                session['Has title'] = [remove_prefix(session_wiki_name)]
             except IndexError as e:
                 warn("  Skipping malformed session wiki name {0}.".format(session_wiki_name))
                 continue


### PR DESCRIPTION
If the page title is 'Session:Title:MoreTitle', just remove
'Session' to extract the title, and don't discard 'MoreTitle'.

The problem is that str.split(':', 2) splits str into 3 parts (and not 2). 