### PR TITLE
validator.xsd: improved duration regex

### DIFF
--- a/validator/xsd/schedule.xml.xsd
+++ b/validator/xsd/schedule.xml.xsd
@@ -82,7 +82,7 @@
 
   <xs:simpleType name="duration">
     <xs:restriction base="xs:string">
-      <xs:pattern value="([0-9]{1,2}:[0-9]{2})|([0-9]{1,2}:[0-9]{2}:[0-9]{1,2})"/>
+      <xs:pattern value="[0-9]{1,2}:([0-5][0-9]|[0-9])(:([0-5][0-9]|[0-9]))?"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
it now forbids values like 10:90:90 or 10:61.

taken from https://github.com/openeventstack/pretalx/pull/136/files