### PR TITLE
[xsd] name attribute for room node is mandatory

### DIFF
--- a/validator/xsd/schedule-without-person.xml.xsd
+++ b/validator/xsd/schedule-without-person.xml.xsd
@@ -52,7 +52,7 @@
     <xs:sequence>
       <xs:element type="event" name="event" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
-    <xs:attribute type="xs:string" name="name"/>
+    <xs:attribute type="xs:string" name="name" use="required"/>
   </xs:complexType>
 
   <xs:complexType name="event">

--- a/validator/xsd/schedule.xml.xsd
+++ b/validator/xsd/schedule.xml.xsd
@@ -52,7 +52,7 @@
     <xs:sequence>
       <xs:element type="event" name="event" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
-    <xs:attribute type="xs:string" name="name"/>
+    <xs:attribute type="xs:string" name="name" use="required"/>
   </xs:complexType>
 
   <xs:complexType name="event">


### PR DESCRIPTION
First of all, thanks for developing such nice tooling for conference management.

Most app misbehave when a room node is lacking the name attribute.