### PR TITLE
fix timestamp and bug with wiki-guids 

### DIFF
--- a/schedule_camp2019.py
+++ b/schedule_camp2019.py
@@ -83,7 +83,7 @@ def generate_wiki_schedule(wiki_url: str, full_schedule: Schedule):
     load_sos_ids()
 
     # process_wiki_events() fills global variables: out, wiki_schedule, workshop_schedule
-    process_wiki_events(data, wiki_schedule)
+    process_wiki_events(data, wiki_schedule, timestamp_offset=-7200)
 
     store_sos_ids()
     

--- a/wiki2schedule.py
+++ b/wiki2schedule.py
@@ -218,7 +218,11 @@ def process_wiki_events(wiki, wiki_schedule, workshop_schedule = None):
                     guid = voc.tools.gen_uuid(session['fullurl'] + str(event['Has start time'][0]))
                 used_guids.append(guid)
 
-                local_id = voc.tools.get_id(guid)
+                try:
+                    local_id = voc.tools.get_id(guid)
+                except TypeError:
+                    local_id = voc.tools.get_id(guid['fulltext'])
+                    guid = guid['fulltext']
 
                 event_n = Event([
                     ('id', local_id),

--- a/wiki2schedule.py
+++ b/wiki2schedule.py
@@ -118,8 +118,12 @@ warnings = False
 events_with_warnings = 0
 events_in_halls_with_warnings = 0
 
-def process_wiki_events(wiki, wiki_schedule, workshop_schedule = None):
-    global sessions_complete, warnings
+def process_wiki_events(wiki, wiki_schedule, workshop_schedule = None, timestamp_offset = None):
+    global sessions_complete, warnings, time_stamp_offset
+
+    if not timestamp_offset == None:
+        time_stamp_offset = timestamp_offset
+
     sessions_complete = OrderedDict()
     events_total = 0
     events_successful = 0


### PR DESCRIPTION
Sometimes `guid` is an `OrderedDict` and sometimes not. This workaround catches the `TypeError` that occurs when there is, so the SoS can be included.
Also the timestamp-offset has changed, so it was corrected.