### PR TITLE
Allow to identify which code was used to generate the output files.

### DIFF
--- a/schedule_divoc.py
+++ b/schedule_divoc.py
@@ -94,6 +94,10 @@ def main():
     print('  version: ' + full_schedule.version())
     print('  contains {events_count} events, with local ids from {min_id} to {max_id}'.format(**full_schedule.stats.__dict__))
 
+    repo = gitlib.Repo(search_parent_directories=True)
+    git_hash = repo.head.object.hexsha
+    full_schedule._schedule['schedule']['generator'] = { "name": "voc/schedule/divoc", "version": git_hash }
+
     # add additional rooms from this local config now, so they are in the correct order
     for key in rooms:
         full_schedule.add_rooms(rooms[key])


### PR DESCRIPTION
+ Add `created_from_git_hash` element to _everything.schedule.xml|json_.
+ This makes it easier to see if a change in the scripts are deployed at the server.

# TODOs
- [x] Add element to validation rules. – not necessary as the field already exits in schedule.xml...
- [ ] Ask Pretalx to add generator element to schedule.json and maybe add the repo url
- [ ] Move element to the top of the file next to the rest of the "meta" information.
- [ ] Append `-dirty` if the working directory is not clean.