### PR TITLE
Improve maintainability, reduce PEP 8 warnings

### DIFF
--- a/schedule_divoc.py
+++ b/schedule_divoc.py
@@ -12,6 +12,7 @@ import sys
 import traceback
 import optparse
 from voc.schedule import Schedule, ScheduleEncoder, Event, set_validator_filter
+from wikitable2schedule import fetch_schedule
 
 tz = pytz.timezone('Europe/Amsterdam')
 
@@ -63,15 +64,14 @@ if not os.path.exists(output_dir):
         exit(-1)
 os.chdir(output_dir)
 
-#if not os.path.exists("events"):
+# if not os.path.exists("events"):
 #    os.mkdir("events")
 
-
-from wikitable2schedule import fetch_schedule
 
 def write(x):
     sys.stdout.write(x)
     sys.stdout.flush()
+
 
 def generate_wiki_schedule(wiki_url: str, full_schedule: Schedule):
 
@@ -91,19 +91,16 @@ def main():
     print('  version: ' + full_schedule.version())
     print('  contains {events_count} events, with local ids from {min_id} to {max_id}'.format(**full_schedule.stats.__dict__))
 
-
-
-    # add addional rooms from this local config now, so they are in the correct order
+    # add additional rooms from this local config now, so they are in the correct order
     for key in rooms:
         full_schedule.add_rooms(rooms[key])
-
 
     previous_max_id = 0
 
     # add events from additional_schedule's to full_schedule
     for entry in additional_schedule_urls:
         try:
-            #other_schedule = get_schedule(entry['name'], entry['url'])
+            # other_schedule = get_schedule(entry['name'], entry['url'])
             other_schedule = Schedule.from_url(entry['url'])
 
             if 'version' in other_schedule.schedule():
@@ -120,7 +117,7 @@ def main():
             max_id = other_schedule.stats.max_id + id_offset
             print('    after adding the offset, ids reach from {} to {}'.format(min_id, max_id))
             if previous_max_id >= min_id:
-                 print('  WARNING: schedule "{}" has ID overlap with previous schedule'.format(entry['name']))
+                print('  WARNING: schedule "{}" has ID overlap with previous schedule'.format(entry['name']))
             previous_max_id = max_id
 
             if full_schedule.add_events_from(other_schedule, id_offset=id_offset, options=entry.get('options')):
@@ -146,13 +143,13 @@ def main():
     write('\nExporting... ')
     full_schedule.export('everything')
 
-    # write seperate file for each event, to get better git diffs
-    #full_schedule.foreach_event(lambda event: event.export('events/'))
-    #def export_event(event):
+    # write separate file for each event, to get better git diffs
+    # full_schedule.foreach_event(lambda event: event.export('events/'))
+    # def export_event(event):
     #    with open("events/{}.json".format(event['guid']), "w") as fp:
     #        json.dump(event, fp, indent=2, cls=ScheduleEncoder)
     #
-    #full_schedule.foreach_event(export_event)
+    # full_schedule.foreach_event(export_event)
 
     print('\nDone')
     print('  version: ' + full_schedule.version())
@@ -173,7 +170,8 @@ def main():
         else:
             git('add *.json *.xml')
             git('commit -m "version {}"'.format(full_schedule.version()))
-            #git('push')
+            # git('push')
+
 
 if __name__ == '__main__':
     main()

--- a/voc/c3data.py
+++ b/voc/c3data.py
@@ -9,7 +9,7 @@ transport = AIOHTTPTransport(
   url=getenv('C3D_URL', 'https://data.c3voc.de/graphql'), 
   headers={'Authorization': getenv('C3D_TOKEN', 'Basic|Bearer XXXX')}
 )
-#transport = AIOHTTPTransport(url="http://localhost:5001/graphql")
+# transport = AIOHTTPTransport(url="http://localhost:5001/graphql")
 
 # Create a GraphQL client using the defined transport
 client = Client(transport=transport, fetch_schema_from_transport=True)
@@ -81,7 +81,6 @@ def create_conference(schedule: Schedule):
     return result
 
 
-
 def add_room(confernce_id, room_name):
   result = client.execute(gql('''
     mutation addRoom($input: UpsertRoomInput!) {
@@ -100,6 +99,7 @@ def add_room(confernce_id, room_name):
 
   print(result)
   return result['upsertRoom']['room']['guid']
+
 
 def add_event(conference_id, room_id, event):
   input = {
@@ -131,15 +131,16 @@ def add_event(conference_id, room_id, event):
     print(e)
     print()
 
+
 def test():
-  #schedule = Schedule.from_url('https://fahrplan.events.ccc.de/camp/2019/Fahrplan/schedule.json')
-  #schedule = Schedule.from_file('divoc/everything.schedule.json')
+  # schedule = Schedule.from_url('https://fahrplan.events.ccc.de/camp/2019/Fahrplan/schedule.json')
+  # schedule = Schedule.from_file('divoc/everything.schedule.json')
   schedule = Schedule.from_file('36c3/everything.schedule.json')
 
-  #result = create_conference(schedule)
-  conference_id = 1 # result['conference']['id']
-  room_ids = {} #{ x['name']: x['guid'] for x in result['conference']['rooms']['nodes'] }
-  #print(room_ids)
+  # result = create_conference(schedule)
+  conference_id = 1  # result['conference']['id']
+  room_ids = {}  # { x['name']: x['guid'] for x in result['conference']['rooms']['nodes'] }
+  # print(room_ids)
 
   def process(event):
     if event['room'] in room_ids:

--- a/voc/rc3hub.py
+++ b/voc/rc3hub.py
@@ -15,6 +15,7 @@ headers = {
     'Accept': 'application/json'
 }
 
+
 def get(path):
     print('GET ' + url + path)
     r = requests.get(url + path, headers=headers)
@@ -56,6 +57,7 @@ def depublish_event(event_guid):
         'public': False
     })
 
+
 skip = False
 tracks = []
 
@@ -65,11 +67,12 @@ def init(channels):
 
     tracks = {x['name']: x['id'] for x in get('tracks')}
 
+
 def full_sync():
     schedule = Schedule.from_url('https://data.c3voc.de/rC3/everything.schedule.json')
 
-    #schedule = Schedule.from_url('https://data.c3voc.de/rC3/channels.schedule.json')
-    #schedule = Schedule.from_file('rC3/channels.schedule.json')
+    # schedule = Schedule.from_url('https://data.c3voc.de/rC3/channels.schedule.json')
+    # schedule = Schedule.from_file('rC3/channels.schedule.json')
     
     channel_room_ids = {x['schedule_room']: x['room_guid'] for x in channels}
     rooms = get('rooms')

--- a/voc/schedule.py
+++ b/voc/schedule.py
@@ -10,17 +10,18 @@ import os
 import re
 import copy
 from lxml import etree as ET
-#from xml.etree import cElementTree as ET
+# from xml.etree import cElementTree as ET
 
 try:
     import voc.tools as tools
 except:
     import tools
 
-#validator = '{path}/validator/xsd/validate_schedule_xml.sh'.format(path=sys.path[0])
-#validator = 'xmllint --noout --schema {path}/validator/xsd/schedule.xml.xsd'.format(path=sys.path[0])
+# validator = '{path}/validator/xsd/validate_schedule_xml.sh'.format(path=sys.path[0])
+# validator = 'xmllint --noout --schema {path}/validator/xsd/schedule.xml.xsd'.format(path=sys.path[0])
 validator = 'xmllint --noout --schema {path}/validator/xsd/schedule-without-person.xml.xsd'.format(path=sys.path[0])
 validator_filter = ''
+
 
 def set_validator_filter(filter):
     global validator_filter
@@ -35,11 +36,12 @@ class Day:
     _day = None
     start = None
     end = None
+
     def __init__(self, i = None, year = None, month = 12, day = None, json = None):
         if json:
             self._day = json
         elif i and year and day:
-           self._day = {
+            self._day = {
                 "index": i+1,
                 "date": "{}-12-{}".format(year, day),
                 "day_start": "{}-12-{}T06:00:00+01:00".format(year, day),
@@ -104,8 +106,8 @@ class Event(collections.abc.Mapping):
     # export all attributes which are not part of rC3 core event model
     def meta(self):
         r = OrderedDict(self._event.items())
-        #r['local_id'] = self._event['id']
-        #del r["id"]
+        # r['local_id'] = self._event['id']
+        # del r["id"]
         del r['guid']
         del r['slug']
         del r['room']
@@ -114,8 +116,8 @@ class Event(collections.abc.Mapping):
         del r['duration']
         del r['track_id']
         del r['track']
-        #del r['persons']
-        #if 'answers' in r:
+        # del r['persons']
+        # if 'answers' in r:
         #    del r['answers']
         # fix wrong formatted links
         if len(r['links']) > 0 and isinstance(r['links'][0], str):
@@ -131,9 +133,7 @@ class Event(collections.abc.Mapping):
 
 
 class Schedule:
-    '''
-    Schedule class with import and export methods
-    '''
+    """ Schedule class with import and export methods """
     _schedule = None
     _days = []
     _room_ids = {}
@@ -143,7 +143,7 @@ class Schedule:
 
     def __init__(self, name = None, url = None, json = None):
         # TODO remove or revert class methods below to object methods
-        #if url:
+        # if url:
         #    self.from_url(url)
         if json:
             self._schedule = json
@@ -154,12 +154,12 @@ class Schedule:
     @classmethod
     def from_url(cls, url):
         print("Requesting " + url)
-        schedule_r = requests.get(url) #, verify=False)
+        schedule_r = requests.get(url)  # , verify=False)
 
         if schedule_r.ok is False:
             raise Exception("  Request failed, HTTP {0}.".format(schedule_r.status_code))
 
-        #self.schedule = tools.parse_json(schedule_r.text)
+        # self.schedule = tools.parse_json(schedule_r.text)
 
         # this more complex way is necessary
         # to maintain the same order as in the input file
@@ -269,7 +269,6 @@ class Schedule:
 
         return rooms.keys()
 
-
     def add_rooms(self, rooms):
         for day in self._schedule['schedule']['conference']['days']:
             for key in rooms:
@@ -286,7 +285,7 @@ class Schedule:
         if not data or len(data) == 0:
             return
 
-        #print('  adding room {} to day {} with {} events'.format(target_room, day, len(data)))
+        # print('  adding room {} to day {} with {} events'.format(target_room, day, len(data)))
         target_day_rooms = self.days()[day-1]['rooms']
 
         if self.room_exists(day, target_room):
@@ -306,7 +305,6 @@ class Schedule:
             self.add_room(day, event['room'])
 
         self.days()[day-1]['rooms'][event['room']].append(event)
-
 
     def foreach_event(self, func):
         out = []
@@ -354,7 +352,6 @@ class Schedule:
                         self.stats.person_max_id = int(person['id'])
 
         self.foreach_event(calc_stats)
-      
 
     def get_day_from_time(self, start_time):
         for i in range(self.conference()['daysCount']):
@@ -471,7 +468,6 @@ class Schedule:
 
         return result[0]
 
-
     def remove_event(self, id = None, guid = None):
         if not id and not guid:
             raise RuntimeError('Please provide either id or guid')
@@ -556,7 +552,8 @@ class Schedule:
                             k = 'event'
 
                         if k == 'days':
-                            # in the xml schedule days are not a child of a conference, but directly in the document node
+                            # in the xml schedule days are not a child of a conference,
+                            # but directly in the document node
                             node_ = root_node
 
                         # special handing for collections: days, rooms etc.
@@ -605,6 +602,7 @@ class Schedule:
             return ET.tounicode(root_node, pretty_print = True)
         else:
             return ET.tostring(root_node, pretty_print = True, encoding='UTF-8')
+
 
 class ScheduleEncoder(json.JSONEncoder):
     def default(self, obj):

--- a/voc/tools.py
+++ b/voc/tools.py
@@ -26,20 +26,23 @@ def set_base_id(value):
 def get_id(guid):
     global sos_ids, next_id, generated_ids
     if guid not in sos_ids:
-        #generate new id
+        # generate new id
         sos_ids[guid] = next_id
         next_id += 1
         generated_ids += 1
 
     return sos_ids[guid]
 
+
 def gen_random_uuid():
     return uuid.uuid4()
+
 
 def gen_uuid(name):
     return str(uuid.uuid5(uuid_namespace, str(name)))
 
-# depreacated, use Schedule.foreach_event() instead
+
+# deprecated, use Schedule.foreach_event() instead
 # TODO remove
 def foreach_event(schedule, func):
     out = []
@@ -63,6 +66,7 @@ def copy_base_structure(subtree, level):
                 ret[key] = copy_base_structure(value, level-1)
     return ret
 
+
 def copy_base_structure_list(subtree, level):
     ret = []
     if level > 0:
@@ -82,21 +86,23 @@ def normalise_string(string):
     string = string.replace(u'ö', 'oe')
     string = string.replace(u'ü', 'ue')
     string = string.replace(u'ß', 'ss')
-    string = re.sub('\W+', '\_', string.strip()) # replace whitespace with _
+    string = re.sub('\W+', '\_', string.strip())  # replace whitespace with _
     # string = filter(unicode.isalnum, string)
     string = re.sub('[^a-z0-9_]+', '', string) # TODO: is this not already done with \W+  line above?
-    string = string.strip('_') # remove trailing _
+    string = string.strip('_')  # remove trailing _
 
     return string
+
 
 def normalise_time(timestr):
     timestr = timestr.replace('p.m.', 'pm')
     timestr = timestr.replace('a.m.', 'am')
-    ## workaround for failure in input file format
+    # workaround for failure in input file format
     if timestr.startswith('0:00'):
         timestr = timestr.replace('0:00', '12:00')
 
     return timestr
+
 
 def parse_json(text):
     # this more complex way is necessary
@@ -106,9 +112,8 @@ def parse_json(text):
 
 def load_json(filename):
     with open(filename, "r") as fp:
-        #data = json.load(fp) 
+        # data = json.load(fp)
         # maintain order from file
         data = parse_json(fp.read())
         
     return data
-    

--- a/wikitable2schedule.py
+++ b/wikitable2schedule.py
@@ -112,6 +112,11 @@ def fetch_schedule(wiki_url):
 
     print('Processing sections')
     section_title = None
+    sections_to_ignore = [
+        'durchgehende_treffpunkte_und_assemblies',
+        'wochentag_datum',
+        'regelmaessige_treffen'
+    ]
     for element in elements:
         if element.name == 'h3' or element.name == 'h2':
             section_title = element
@@ -119,7 +124,7 @@ def fetch_schedule(wiki_url):
 
         # ignore some sections
         if element.name == 'table':
-            if section_title.attrs['id'] in ['durchgehende_treffpunkte_und_assemblies', 'wochentag_datum', 'regelmaessige_treffen']:
+            if section_title.attrs['id'] in sections_to_ignore:
                 continue
 
         day = section_title.text.split(',')[1].strip() + "{}".format(year)

--- a/wikitable2schedule.py
+++ b/wikitable2schedule.py
@@ -1,4 +1,4 @@
- # -*- coding: UTF-8 -*-
+# -*- coding: UTF-8 -*-
 from typing import Dict
 
 import requests
@@ -19,13 +19,12 @@ from voc.schedule import Schedule, ScheduleEncoder, Event, set_validator_filter
 
 from bs4 import BeautifulSoup, Tag
 
+# some functions used in multiple files of this collection
+import voc.tools
 
 days = []
 local = False
 locale.setlocale(locale.LC_ALL, 'de_DE.UTF-8')
-
-# some functions used in multiple files of this collection
-import voc.tools
 
 voc.tools.set_base_id(1000)
 
@@ -35,7 +34,7 @@ output_dir = "/srv/www/schedule/divoc"
 secondary_output_dir = "./divoc"
 
 
-template = { "schedule": {
+template = {"schedule": {
         "version": "1.0",
         "conference": {
             "title": "divoc - r2r",
@@ -45,11 +44,12 @@ template = { "schedule": {
             "end":   "2021-04-05",
             "timeslot_duration": "00:15",
             "time_zone_name": "Europe/Amsterdam",
-            "days" : [],
+            "days": [],
             "base_url": "https://di.c3voc.de/",
         },
     }
 }
+
 
 def get_track_id(track_name):
     return 10
@@ -75,7 +75,6 @@ def parse_html_formatted_links(td: Tag) -> Dict[str, str]:
 
 def fetch_schedule(wiki_url):
     global template, days
-    
 
     # TODO refactor schedule class, to allow more generic templates
 
@@ -85,20 +84,19 @@ def fetch_schedule(wiki_url):
     
     for i in range(out['schedule']['conference']['daysCount']):
         date = conference_start_date + timedelta(days=i)
-        start = date + timedelta(hours=9) # conference day starts at 9:00
-        end = start + timedelta(hours=20) # conference day lasts 20 hours
+        start = date + timedelta(hours=9)  # conference day starts at 9:00
+        end = start + timedelta(hours=20)  # conference day lasts 20 hours
         
-        days.append( OrderedDict([
+        days.append(OrderedDict([
             ('index', i),
-            ('date' , date),
+            ('date', date),
             ('start', start),
             ('end', end),
         ]))
-        
-        
+
         out['schedule']['conference']['days'].append(OrderedDict([
             ('index', i+1),
-            ('date' , date.strftime('%Y-%m-%d')),
+            ('date', date.strftime('%Y-%m-%d')),
             ('day_start', start.isoformat()),
             ('day_end', end.isoformat()),
             ('rooms', OrderedDict())
@@ -107,9 +105,9 @@ def fetch_schedule(wiki_url):
     print("Requesting wiki events")
     
     soup = BeautifulSoup(requests.get(wiki_url).text, 'html5lib')
-    #soup = BeautifulSoup(open("divoc-sessions.xhtml"), 'lxml')
+    # soup = BeautifulSoup(open("divoc-sessions.xhtml"), 'lxml')
 
-    #sections = soup.find_all('h3')
+    # sections = soup.find_all('h3')
     elements = soup.select('h3, h2, table.inline')
 
     print('Processing sections')
@@ -143,7 +141,7 @@ def fetch_schedule(wiki_url):
             data = {}
             external_links = {}
             for td in row.find_all('td'):
-                #if type(td) != NoneType:
+                # if type(td) != NoneType:
                 key = td.attrs['class'][0]
                 data[key] = re.compile(r'\s*\n\s*').split(td.get_text().strip())
                 external_links = parse_html_formatted_links(td)
@@ -158,7 +156,7 @@ def fetch_schedule(wiki_url):
                 local_id = voc.tools.get_id(guid)
                 duration = (end - start).total_seconds()/60
                 
-                #room = 'Kidspace' if 'Kidspace' in persons else 'Self-organized'
+                # room = 'Kidspace' if 'Kidspace' in persons else 'Self-organized'
                 room = 'Workshops' if 'Workshop' in title or 'Workshop' in abstract else 'Self-organized'
                 
                 event_n = OrderedDict([
@@ -179,14 +177,14 @@ def fetch_schedule(wiki_url):
                     ('subtitle', ''),
                     ('track', 'Workshop'),
                     ('type', 'Workshop'),
-                    ('language', 'de' ),
+                    ('language', 'de'),
                     ('abstract', abstract or ''),
-                    ('description', '' ),
-                    ('persons', [ OrderedDict([
+                    ('description', ''),
+                    ('persons', [OrderedDict([
                         ('id', 0),
                         ('public_name', p.strip()),
-                        #('#text', p),
-                    ]) for p in persons.split(',') ]),
+                        # ('#text', p),
+                    ]) for p in persons.split(',')]),
                     ('links', [ 
                         {'url': link_url, 'title': link_title} for link_url, link_title in external_links.items()
                     ])
@@ -203,14 +201,14 @@ def fetch_schedule(wiki_url):
                 print(data)
                 print(json.dumps(event_n, indent=2))
                 print()
-        
-            
-    #print(json.dumps(out, indent=2))
+
+    # print(json.dumps(out, indent=2))
     print()
     print()
     
     schedule = Schedule(json=out)
     return schedule
+
 
 def main():
 
@@ -219,6 +217,7 @@ def main():
     
     print('')
     print('end')
+
 
 def get_day(start_time):
     for day in days:
@@ -230,11 +229,13 @@ def get_day(start_time):
     print("  illegal start time: " + start_time.isoformat())   
     return None
 
+
 def first(x):
     if len(x) == 0:
         return None
     else:
         return x[0]
+
 
 if __name__ == '__main__':
 
@@ -253,5 +254,5 @@ if __name__ == '__main__':
 
     if not local:  
         os.system("git add *.json *.xml")
-        os.system("git commit -m 'updates from " + str(datetime.now()) +  "'")
+        os.system("git commit -m 'updates from " + str(datetime.now()) + "'")
         os.system("git push")


### PR DESCRIPTION
I noticed that a lot of PEP 8 warnings are shown when I load the project into PyCharm.
Here, I am trying to reduce the "noise" somewhat so important warnings/errors are visible in the IDE.

Future: Once the files are clean one could even add a PEP check to the CI pipeline to avoid warnings to return.