### PR TITLE
Support up to three workshops taking place at the same time.

### DIFF
--- a/wikitable2schedule.py
+++ b/wikitable2schedule.py
@@ -159,7 +159,14 @@ def fetch_schedule(wiki_url):
                 duration = (end - start).total_seconds()/60
                 
                 #room = 'Kidspace' if 'Kidspace' in persons else 'Self-organized'
-                room = 'Workshops' if 'Workshop' in title or 'Workshop' in abstract else 'Self-organized'
+                if 'Workshop1' in title or 'Workshop1' in abstract:
+                    room = 'Workshops1'
+                elif 'Workshop2' in title or 'Workshop2' in abstract:
+                    room = 'Workshops2'
+                elif 'Workshop3' in title or 'Workshop3' in abstract:
+                    room = 'Workshops3'
+                else:
+                    room = 'Self-organized'
                 
                 event_n = OrderedDict([
                     ('id', local_id),


### PR DESCRIPTION
+ If the start time of multiple self-organized session is the same and the session description contains the term `Workshop1`, `Workshop2` or `Workshop3` then these sessions are distributed to virtual rooms.
+ This solves an issue in the Android app which cannot render session with the same start time.
+ Related: 6a9bbd11a8333369497ed639da76422dc76c394b.

---

Related SOS: https://di.c3voc.de/sessions-liste