### PR TITLE
Synchronize schedule-without-person.xml / Add regex for slug and acronym.

### DIFF
--- a/validator/xsd/schedule-without-person.xml.xsd
+++ b/validator/xsd/schedule-without-person.xml.xsd
@@ -15,7 +15,7 @@
           <xs:complexType>
             <xs:all>
               <xs:element type="xs:string"  name="title"/>
-              <xs:element type="xs:string"  name="acronym"/>
+              <xs:element type="acronym"  name="acronym"/>
 
               <xs:element type="xs:date"    name="start" minOccurs="0"/>
               <xs:element type="xs:date"    name="end" minOccurs="0"/>
@@ -79,7 +79,7 @@
       <xs:element type="start" name="start"/>
       <xs:element type="duration" name="duration"/>
       <xs:element type="xs:string" name="abstract"/>
-      <xs:element type="xs:string" name="slug"/>
+      <xs:element type="slug" name="slug"/>
       <xs:element type="xs:string" name="track"/>
 
       <xs:element type="xs:string" name="logo" minOccurs="0"/>
@@ -117,6 +117,18 @@
   <xs:simpleType name="uuid">
     <xs:restriction base="xs:string">
       <xs:pattern value="[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="acronym">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z0-9_-]{4,}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="slug">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z0-9]{4,}-[0-9]{1,6}-[a-z0-9\-_]{4,}"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
+ Add regex for `slug` and `acronym` to `schedule-without-person.xml`.
  + Related commits: 1e22ff63d1b03e959fdf0b9771beeee7bae1b75e, 6d81e3f4a86efe736780e3b3f87dda24a9e70dd1

# To be discussed
+ The file also missed `<xs:element type="httpURI" name="video_download_url" minOccurs="0"/>` but I am not sure if it should be there or removed from `schedule.xml.xsd`, too. Can you please clarify?