### PR TITLE
Fix schema validity error regarding the order of the "generator" element.

### DIFF
--- a/voc/schedule.py
+++ b/voc/schedule.py
@@ -267,6 +267,7 @@ class Schedule:
 
     def reset_generator(self):
         self._schedule['schedule']['generator'] = tools.generator_info()
+        self._schedule["schedule"].move_to_end('generator', last=False)
 
     def copy(self, name):
         schedule = copy.deepcopy(self._schedule)


### PR DESCRIPTION
# Error message

> Schemas validity error : Element 'generator': This element is not expected. Expected is ( day )

# Successfully tested with

- `schedule_divoc.py`

---

Resolves #86