### PR TITLE
Draft: add additional flag for do_not_stream / recording optout enum

### DIFF
--- a/validator/json/schema.json
+++ b/validator/json/schema.json
@@ -266,10 +266,12 @@
           "type": "string"
         },
         "do_not_record": {
-          "type":  ["boolean", "null"]
+          "type":  ["boolean", "string", "null"],
+          "description": "If this value is set to `true`, the speaker does not want a recording of any kind. We will remove all video staff and maybe even switch off all cameras"
         },
         "do_not_stream": {
-          "type":  ["string", "null"]
+          "type":  ["string", "boolean", "null"],
+          "description": "If this value is set to boolean `false`, the speaker is okay with a live stream of the event; and is aware that somebody in the internet might create third party recording"
         },
         "persons": {
           "type": "array",

--- a/validator/xsd/schedule.xml.xsd
+++ b/validator/xsd/schedule.xml.xsd
@@ -250,7 +250,7 @@
       <xs:enumeration value="true"/>
       <!-- Recording optout status 'maybe': We are allowed to create a recording / enable the live stream; but the speaker can decide afterwards if we can publish it  -->
       <xs:enumeration value="maybe"/>
-      <!-- Recording optout status 'unknown': We don't now if an recording will exist and recommend all on-premise participants to attent the event in persion -->
+      <!-- Recording optout status 'unknown': We don't now if a recording will exist and recommend all on-premise participants to attend the event in person -->
       <xs:enumeration value="unknown"/>
     </xs:restriction>
   </xs:simpleType>

--- a/validator/xsd/schedule.xml.xsd
+++ b/validator/xsd/schedule.xml.xsd
@@ -173,7 +173,7 @@
   <xs:complexType name="recording">
     <xs:all>
       <xs:element type="xs:string"  name="license"/>
-      <xs:element type="xs:boolean" name="optout"/>
+      <xs:element type="optoutEnum" name="optout"/>
       <xs:element type="httpURI" name="url" minOccurs="0"/>
       <xs:element type="httpURI" name="link" minOccurs="0"/>
     </xs:all>
@@ -241,5 +241,18 @@
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
+
+  <xs:simpleType name="optoutEnum">
+    <xs:restriction base="xs:string">
+      <!-- Recording optout status 'false' is the normal case: We enable the live stream and create a recording, which we publish without and feedback from the speaker -->
+      <xs:enumeration value="false"/>
+      <!-- Recording optout status 'true' means: The speaker does not want a recording of any kind. We will remove all personnel, and maybe even switch off all cameras -->
+      <xs:enumeration value="true"/>
+      <!-- Recording optout status 'maybe': We are allowed to create a recording / enable the live stream; but the speaker can decide afterwards if we can publish it  -->
+      <xs:enumeration value="maybe"/>
+      <!-- Recording optout status 'unknown': We don't now if an recording will exist and recommend all on-premise participants to attent the event in persion -->
+      <xs:enumeration value="unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
 
 </xs:schema>

--- a/voc/schedule.py
+++ b/voc/schedule.py
@@ -500,6 +500,9 @@ class Schedule(dict):
                     if options.get("do_not_record"):
                         event["do_not_record"] = options['do_not_record'](event) if callable(options["do_not_record"]) else options["do_not_record"]
 
+                    if options.get("do_not_stream"):
+                        event["do_not_stream"] = options['do_not_stream'](event) if callable(options["do_not_stream"]) else options["do_not_stream"]
+
                     if options.get("remove_title_additions"):
                         # event["title"], subtitle, event_type = re.match(r"^(.{15,}?)(?:(?::| [–-]+) (.+?))?(?: \((.+?)\))?$", event["title"]).groups()
 
@@ -698,7 +701,7 @@ class Schedule(dict):
                             # not in schedule.json: license information for an event
                             v = {
                                 "license": recording_license,
-                                "optout": "true" if v is True else "false",
+                                "optout": "true" if v is True else v,
                             }
                         # new style schedule.json (version 2022-12)
                         elif k == "optout":


### PR DESCRIPTION
relates to #117 

| schedule.json | schedule.xml | | 
| --- | --- | --- | 
| missing, or  <br/> ```"do_not_record": false``` or  <br/> ```"do_not_record": false, "do_not_stream": false,``` |  `<recording>…<optout>false</optout></recording>` |  We enable the live stream and create a recording, which we publish without any additional approval by speaker |
| ```"do_not_record": true, "do_not_stream": true,``` |  `<recording>…<optout>true</optout></recording>` | The speaker does not want a recording of any kind. We will remove all personnel, and maybe even switch off all cameras |
| ```"do_not_record": null, "do_not_stream": false,``` | `<recording>…<optout>maybe</optout></recording>` |  NEW: We are allowed to create a recording / enable the live stream; but the speaker can decide afterwards if we can publish it |
| ```"do_not_record": null, "do_not_stream": null,``` | `<recording>…<optout>unknown</optout></recording>` | NEW: We don't know if a recording will exist and recommend all on-premise participants to attend the event in person | 